### PR TITLE
don't expose email in UserTransformer

### DIFF
--- a/resources/assets/js/comments-react/components/Comment.jsx
+++ b/resources/assets/js/comments-react/components/Comment.jsx
@@ -63,7 +63,7 @@ class Comment extends Component
     }
 
     render() {
-        let email_hash = "//www.gravatar.com/avatar/" + md5(this.props.comment.user.data.email) + ".jpg?s=60";
+        let email_hash = "//www.gravatar.com/avatar/" + this.props.comment.user.data.email_hash + ".jpg?s=60";
         let datetime = moment(this.props.comment.created_at, 'YYYY-MM-DD HH:mm:ss').fromNow();
 
         let content = (

--- a/src/Comments/UserTransformer.php
+++ b/src/Comments/UserTransformer.php
@@ -10,7 +10,7 @@ class UserTransformer extends TransformerAbstract
         return [
             'id' => (int) $user->id,
             'name' => $user->name,
-            'email' => $user->email
+            'email_hash' => md5($user->email)
         ];
     }
 

--- a/src/Comments/UserTransformer.php
+++ b/src/Comments/UserTransformer.php
@@ -10,7 +10,7 @@ class UserTransformer extends TransformerAbstract
         return [
             'id' => (int) $user->id,
             'name' => $user->name,
-            'email_hash' => md5($user->email)
+            'email_hash' => md5(strtolower(trim($user->email))),
         ];
     }
 


### PR DESCRIPTION
we don't need the exact email - we only need the md5
of the email, so instead only expose the md5 checksum
of the email address in the json