### PR TITLE
Support for non-integer IDs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     ],
     "require": {
         "php": "7.2.*",
+        "doctrine/dbal": "^2.8",
         "illuminate/support": "5.*",
         "illuminate/database": "5.*",
         "illuminate/http": "5.*",

--- a/migrations/2018_11_21_041353_allow_commentable_id_to_be_string.php
+++ b/migrations/2018_11_21_041353_allow_commentable_id_to_be_string.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AllowCommentableIdToBeString extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('comments', function (Blueprint $table) {
+            $table->string('commentable_id')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('comments', function (Blueprint $table) {
+            $table->unsignedBigInteger('commentable_id')->change();
+        });
+    }
+}

--- a/src/CommentsController.php
+++ b/src/CommentsController.php
@@ -23,7 +23,7 @@ class CommentsController extends Controller
     {
         $this->validate($request, [
             'commentable_type' => 'required|string',
-            'commentable_id' => 'required|integer|min:1',
+            'commentable_id' => 'required|string|min:1',
             'message' => 'required|string'
         ]);
 


### PR DESCRIPTION
Re #19: Unable to post comments Laravel 5.6
- Allow commentable_id to be a string

I wanted to accomplish this without modifying your existing migration, for existing users out there. In order to change the existing db column, I had to add the `doctrine/dbal` dependency. This is needed only because I am using `->change()` in the new migration.