### PR TITLE
Support multiple user models

### DIFF
--- a/config/comments.php
+++ b/config/comments.php
@@ -1,9 +1,6 @@
 <?php
 
 return [
-    // The model which creates the comments aka the User model
-    'commenter' => \App\User::class,
-
     'permissions' => [
         'create-comment' => 'Laravelista\Comments\CommentPolicy@create',
         'delete-comment' => 'Laravelista\Comments\CommentPolicy@delete',

--- a/migrations/2019_06_11_133452_add_commenter_type_column_to_comments_table.php
+++ b/migrations/2019_06_11_133452_add_commenter_type_column_to_comments_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddCommenterTypeColumnToCommentsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('comments', function (Blueprint $table) {
+            $table->string('commenter_type')
+              ->after('commenter_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('comments', function (Blueprint $table) {
+            //
+        });
+    }
+}

--- a/src/Comment.php
+++ b/src/Comment.php
@@ -32,7 +32,7 @@ class Comment extends Model
      */
     public function commenter()
     {
-        return $this->belongsTo(config('comments.commenter'));
+        return $this->morphTo();
     }
 
     /**

--- a/src/Commenter.php
+++ b/src/Commenter.php
@@ -13,6 +13,6 @@ trait Commenter
      */
     public function comments()
     {
-        return $this->hasMany(Comment::class, 'commenter_id');
+        return $this->morphMany(Comment::class, 'commenter');
     }
 }


### PR DESCRIPTION
Hi,

Again, thanks for this package.

While working in a project which have many 'user' models (with different login logic, for example), I realized that this package support just one model to be the commenter model.

Now, I wrote an update to make this package support more that one commenter model, the approach I follow:

- Make the relationship between comment and commenter polymorphic (migrations updated).

- Removed unnecessary configuration pointing to the User model.

My experience with Laravel is rather limited, so not sure if this is the best approach, happy to discuss this further.

This change, along with some custom middleware applied to the package routes, is working very well to me.

Thanks,

Enrique
