### PR TITLE
Make auth guards configurable through package configurations

### DIFF
--- a/config/comments.php
+++ b/config/comments.php
@@ -36,6 +36,13 @@ return [
     'routes' => true,
 
     /**
+     * The auth middleware uses the default guard configured in config/auth.php.
+     * You can overwrite this adding a comma separated list of guards that you
+     * want to implement wit this package.
+     */
+    'auth_guards' => 'web',
+
+    /**
      * By default comments posted are marked as approved. If you want
      * to change this, set this option to true. Then, all comments
      * will need to be approved by setting the `approved` column to

--- a/src/CommentController.php
+++ b/src/CommentController.php
@@ -18,7 +18,7 @@ class CommentController extends Controller implements CommentControllerInterface
         if (config('comments.guest_commenting') == true) {
             $this->middleware('auth')->except('store');
         } else {
-            $this->middleware('auth');
+            $this->middleware('auth:' . config('comments.auth_guards'));
         }
     }
 


### PR DESCRIPTION
Hi @mabasic , again thanks for this awesome package.

While working for supporting multiple authenticable models I faced and issue for making other models available for the routes defined in this package.

When we were talking about this feature (PR [#49](https://github.com/laravelista/comments/pull/49)) I mentioned that I was using a custom middleware for making the new authenticable model available for the comments routes. However (I'm still finding my way around Laravel), I was confused by the time with the whole concept of middlewares/guards (tbh, I'm still a little confused). Anyway, what I meant by the time is that I was using a custom **guard**. So, in my config/auth.php file I have the following:

```
'guards' => [
        'web' => [
            'driver' => 'session',
            'provider' => 'users',
        ],
        'chat' => [
            'driver' => 'session',
            'provider' => 'participants',
        ],

        'api' => [
            'driver' => 'token',
            'provider' => 'users',
        ],
    ],

'providers' => [
        'users' => [
            'driver' => 'eloquent',
            'model' => App\Models\User::class,
        ],

        'participants' => [
            'driver' => 'eloquent',
            'model' => App\Models\Participant::class,
        ],
    ],
```

Now, this PR exposes a new configuration, `comments.aut_guard`, and is implemented in the in the constructor for CommentControler.php. This update is fairly simple and I don't think it'll break any functionality, however, I'm not sure this is the best way to implement this or even if it's the Laravel way to do it so any advice on this would be greatly appreciated.

Happy to discuss this issue further, let me know if you need any other info from me.

Thanks,

Enrique