### PR TITLE
Reply comment action now instantiate Comment model from configuration setting

### DIFF
--- a/src/CommentController.php
+++ b/src/CommentController.php
@@ -108,6 +108,8 @@ class CommentController extends Controller implements CommentControllerInterface
             'message' => 'required|string'
         ]);
 
+        $commentClass = config('comments.model');
+        $reply = new $commentClass;
         $reply = new Comment;
         $reply->commenter()->associate(auth()->user());
         $reply->commentable()->associate($comment->commentable);

--- a/src/CommentController.php
+++ b/src/CommentController.php
@@ -110,7 +110,6 @@ class CommentController extends Controller implements CommentControllerInterface
 
         $commentClass = config('comments.model');
         $reply = new $commentClass;
-        $reply = new Comment;
         $reply->commenter()->associate(auth()->user());
         $reply->commentable()->associate($comment->commentable);
         $reply->parent()->associate($comment);


### PR DESCRIPTION
Hi @mabasic , 

This is related to PR [#48](https://github.com/laravelista/comments/pull/48). I missed to update the reply action in CommentController so it'd use the new configuration for Comment model.

I'm creating a new PR because I noticed that you already merged into master the previous PR (awesome mate).

Thanks,

Enrique