### PR TITLE
Add basic spam protection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "illuminate/support": "^5.6",
         "illuminate/database": "^5.6",
         "illuminate/http": "^5.6",
-        "erusev/parsedown": "^1.7"
+        "erusev/parsedown": "^1.7",
+        "spatie/laravel-honeypot": "^1.3"
     },
     "autoload": {
         "psr-4": {

--- a/resources/views/_comment.blade.php
+++ b/resources/views/_comment.blade.php
@@ -23,6 +23,7 @@
                 <form id="comment-delete-form-{{ $comment->id }}" action="{{ url('comments/' . $comment->id) }}" method="POST" style="display: none;">
                     @method('DELETE')
                     @csrf
+                    @honeypot
                 </form>
             @endcan
         </div>
@@ -34,6 +35,7 @@
                         <form method="POST" action="{{ url('comments/' . $comment->id) }}">
                             @method('PUT')
                             @csrf
+                            @honeypot
                             <div class="modal-header">
                                 <h5 class="modal-title">Edit Comment</h5>
                                 <button type="button" class="close" data-dismiss="modal">
@@ -63,6 +65,7 @@
                     <div class="modal-content">
                         <form method="POST" action="{{ url('comments/' . $comment->id) }}">
                             @csrf
+                            @honeypot
                             <div class="modal-header">
                                 <h5 class="modal-title">Reply to Comment</h5>
                                 <button type="button" class="close" data-dismiss="modal">

--- a/resources/views/_form.blade.php
+++ b/resources/views/_form.blade.php
@@ -12,6 +12,7 @@
         @endif
         <form method="POST" action="{{ url('comments') }}">
             @csrf
+            @honeypot
             <input type="hidden" name="commentable_type" value="\{{ get_class($model) }}" />
             <input type="hidden" name="commentable_id" value="{{ $model->id }}" />
 

--- a/src/CommentController.php
+++ b/src/CommentController.php
@@ -14,7 +14,7 @@ class CommentController extends Controller implements CommentControllerInterface
 
     public function __construct()
     {
-        $this->middleware('web', ProtectAgainstSpam::class);
+        $this->middleware(['web', ProtectAgainstSpam::class]);
 
         if (config('comments.guest_commenting') == true) {
             $this->middleware('auth')->except('store');

--- a/src/CommentController.php
+++ b/src/CommentController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Spatie\Honeypot\ProtectAgainstSpam;
 
 class CommentController extends Controller implements CommentControllerInterface
 {
@@ -13,7 +14,7 @@ class CommentController extends Controller implements CommentControllerInterface
 
     public function __construct()
     {
-        $this->middleware('web');
+        $this->middleware('web', ProtectAgainstSpam::class);
 
         if (config('comments.guest_commenting') == true) {
             $this->middleware('auth')->except('store');

--- a/src/routes.php
+++ b/src/routes.php
@@ -1,6 +1,8 @@
 <?php
 
-Route::post('comments', config('comments.controller') . '@store');
+use Spatie\Honeypot\ProtectAgainstSpam;
+
+Route::post('comments', config('comments.controller') . '@store')->middleware(ProtectAgainstSpam::class);
 Route::delete('comments/{comment}', config('comments.controller') . '@destroy');
 Route::put('comments/{comment}', config('comments.controller') . '@update');
 Route::post('comments/{comment}', config('comments.controller') . '@reply');

--- a/src/routes.php
+++ b/src/routes.php
@@ -1,8 +1,6 @@
 <?php
 
-use Spatie\Honeypot\ProtectAgainstSpam;
-
-Route::post('comments', config('comments.controller') . '@store')->middleware(ProtectAgainstSpam::class);
+Route::post('comments', config('comments.controller') . '@store');
 Route::delete('comments/{comment}', config('comments.controller') . '@destroy');
 Route::put('comments/{comment}', config('comments.controller') . '@update');
 Route::post('comments/{comment}', config('comments.controller') . '@reply');


### PR DESCRIPTION
Basic spam protection integrated with the help of [Laravel Honeypot](https://github.com/spatie/laravel-honeypot):


> When adding a form to a public site, there's a risk that spam bots will try to submit it with fake values. Luckily, the majority of these bots are pretty dumb. You can thwart most of them by adding an invisible field to your form that should never contain a value when submitted. Such a field is called a honeypot. These spam bots will just fill all fields, including the honeypot.

The advantage of this package is, that the user do not have to fill out anything and the website owner has no problems with data privacy laws (especially in the EU) because no third party is involved. I think the package is a good starting point for securing forms.

I just secured the `create` route because this is the only route used by guests.
