### PR TITLE
Added Configuration Option to not use Paginator::useBootstrap()

### DIFF
--- a/config/comments.php
+++ b/config/comments.php
@@ -72,4 +72,10 @@ return [
      */
     'load_migrations' => true,
 
+    /**
+     * Enable/disable calling Paginator::useBootstrap() in the boot method
+     * to prevent breaking non bootstrap based Site.
+     */
+    'paginator_use_bootstrap' => true,
+
 ];

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -86,7 +86,9 @@ class ServiceProvider extends LaravelServiceProvider
 
         Route::model('comment', Config::get('comments.model'));
 
-        Paginator::useBootstrap();
+        if (Config::get('comments.paginator_use_bootstrap')) {
+            Paginator::useBootstrap();
+        }
     }
 
     public function register()


### PR DESCRIPTION
The Boot Method now uses Paginator::useBootstrap() only if the configuration has 'paginator_use_bootstrap' => true.
Defaults to the current Behaviour