### PR TITLE
Extract logic to CommentService in order to allow for creating custom ApiCommentController

### DIFF
--- a/config/comments.php
+++ b/config/comments.php
@@ -23,9 +23,10 @@ return [
     /**
      * The Comment Controller.
      * Change this to your own implementation of the CommentController.
-     * You can use the \Laravelista\Comments\CommentControllerInterface.
+     * You can use the \Laravelista\Comments\CommentControllerInterface
+     * or extend the \Laravelista\Comments\CommentController.
      */
-    'controller' => '\Laravelista\Comments\CommentController',
+    'controller' => '\Laravelista\Comments\WebCommentController',
 
     /**
      * Disable/enable the package routes.

--- a/src/CommentController.php
+++ b/src/CommentController.php
@@ -2,130 +2,19 @@
 
 namespace Laravelista\Comments;
 
-use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
-use Illuminate\Support\Facades\Auth;
-use Spatie\Honeypot\ProtectAgainstSpam;
 use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Gate;
-use Illuminate\Support\Facades\Redirect;
-use Illuminate\Support\Facades\URL;
-use Illuminate\Support\Facades\Validator;
+use Spatie\Honeypot\ProtectAgainstSpam;
 
-class CommentController extends Controller implements CommentControllerInterface
+abstract class CommentController extends Controller implements CommentControllerInterface
 {
     public function __construct()
     {
-        $this->middleware('web');
-
         if (Config::get('comments.guest_commenting') == true) {
             $this->middleware('auth')->except('store');
             $this->middleware(ProtectAgainstSpam::class)->only('store');
         } else {
             $this->middleware('auth');
         }
-    }
-
-    /**
-     * Creates a new comment for given model.
-     */
-    public function store(Request $request)
-    {
-        // If guest commenting is turned off, authorize this action.
-        if (Config::get('comments.guest_commenting') == false) {
-            Gate::authorize('create-comment', Comment::class);
-        }
-
-        // Define guest rules if user is not logged in.
-        if (!Auth::check()) {
-            $guest_rules = [
-                'guest_name' => 'required|string|max:255',
-                'guest_email' => 'required|string|email|max:255',
-            ];
-        }
-
-        // Merge guest rules, if any, with normal validation rules.
-        Validator::make($request->all(), array_merge($guest_rules ?? [], [
-            'commentable_type' => 'required|string',
-            'commentable_id' => 'required|string|min:1',
-            'message' => 'required|string'
-        ]))->validate();
-
-        $model = $request->commentable_type::findOrFail($request->commentable_id);
-
-        $commentClass = Config::get('comments.model');
-        $comment = new $commentClass;
-
-        if (!Auth::check()) {
-            $comment->guest_name = $request->guest_name;
-            $comment->guest_email = $request->guest_email;
-        } else {
-            $comment->commenter()->associate(Auth::user());
-        }
-
-        $comment->commentable()->associate($model);
-        $comment->comment = $request->message;
-        $comment->approved = !Config::get('comments.approval_required');
-        $comment->save();
-
-        return Redirect::to(URL::previous() . '#comment-' . $comment->getKey());
-    }
-
-    /**
-     * Updates the message of the comment.
-     */
-    public function update(Request $request, Comment $comment)
-    {
-        Gate::authorize('edit-comment', $comment);
-
-        Validator::make($request->all(), [
-            'message' => 'required|string'
-        ])->validate();
-
-        $comment->update([
-            'comment' => $request->message
-        ]);
-
-        return Redirect::to(URL::previous() . '#comment-' . $comment->getKey());
-    }
-
-    /**
-     * Deletes a comment.
-     */
-    public function destroy(Comment $comment)
-    {
-        Gate::authorize('delete-comment', $comment);
-
-        if (Config::get('comments.soft_deletes') == true) {
-			$comment->delete();
-		}
-		else {
-			$comment->forceDelete();
-		}
-
-        return Redirect::back();
-    }
-
-    /**
-     * Creates a reply "comment" to a comment.
-     */
-    public function reply(Request $request, Comment $comment)
-    {
-        Gate::authorize('reply-to-comment', $comment);
-
-        Validator::make($request->all(), [
-            'message' => 'required|string'
-        ])->validate();
-
-        $commentClass = Config::get('comments.model');
-        $reply = new $commentClass;
-        $reply->commenter()->associate(Auth::user());
-        $reply->commentable()->associate($comment->commentable);
-        $reply->parent()->associate($comment);
-        $reply->comment = $request->message;
-        $reply->approved = !Config::get('comments.approval_required');
-        $reply->save();
-
-        return Redirect::to(URL::previous() . '#comment-' . $reply->getKey());
     }
 }

--- a/src/CommentService.php
+++ b/src/CommentService.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Laravelista\Comments;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Validator;
+
+class CommentService
+{
+    /**
+     * Handles creating a new comment for given model.
+     * @return mixed the configured comment-model
+     */
+    public function store(Request $request)
+    {
+        // If guest commenting is turned off, authorize this action.
+        if (Config::get('comments.guest_commenting') == false) {
+            Gate::authorize('create-comment', Comment::class);
+        }
+
+        // Define guest rules if user is not logged in.
+        if (!Auth::check()) {
+            $guest_rules = [
+                'guest_name' => 'required|string|max:255',
+                'guest_email' => 'required|string|email|max:255',
+            ];
+        }
+
+        // Merge guest rules, if any, with normal validation rules.
+        Validator::make($request->all(), array_merge($guest_rules ?? [], [
+            'commentable_type' => 'required|string',
+            'commentable_id' => 'required|string|min:1',
+            'message' => 'required|string'
+        ]))->validate();
+
+        $model = $request->commentable_type::findOrFail($request->commentable_id);
+
+        $commentClass = Config::get('comments.model');
+        $comment = new $commentClass;
+
+        if (!Auth::check()) {
+            $comment->guest_name = $request->guest_name;
+            $comment->guest_email = $request->guest_email;
+        } else {
+            $comment->commenter()->associate(Auth::user());
+        }
+
+        $comment->commentable()->associate($model);
+        $comment->comment = $request->message;
+        $comment->approved = !Config::get('comments.approval_required');
+        $comment->save();
+
+        return $comment;
+    }
+
+    /**
+     * Handles updating the message of the comment.
+     * @return mixed the configured comment-model
+     */
+    public function update(Request $request, Comment $comment)
+    {
+        Gate::authorize('edit-comment', $comment);
+
+        Validator::make($request->all(), [
+            'message' => 'required|string'
+        ])->validate();
+
+        $comment->update([
+            'comment' => $request->message
+        ]);
+
+        return $comment;
+    }
+
+    /**
+     * Handles deleting a comment.
+     * @return mixed the configured comment-model
+     */
+    public function destroy(Comment $comment): void
+    {
+        Gate::authorize('delete-comment', $comment);
+
+        if (Config::get('comments.soft_deletes') == true) {
+            $comment->delete();
+        } else {
+            $comment->forceDelete();
+        }
+    }
+
+    /**
+     * Handles creating a reply "comment" to a comment.
+     * @return mixed the configured comment-model
+     */
+    public function reply(Request $request, Comment $comment)
+    {
+        Gate::authorize('reply-to-comment', $comment);
+
+        Validator::make($request->all(), [
+            'message' => 'required|string'
+        ])->validate();
+
+        $commentClass = Config::get('comments.model');
+        $reply = new $commentClass;
+        $reply->commenter()->associate(Auth::user());
+        $reply->commentable()->associate($comment->commentable);
+        $reply->parent()->associate($comment);
+        $reply->comment = $request->message;
+        $reply->approved = !Config::get('comments.approval_required');
+        $reply->save();
+
+        return $reply;
+    }
+}

--- a/src/WebCommentController.php
+++ b/src/WebCommentController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Laravelista\Comments;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Redirect;
+use Illuminate\Support\Facades\URL;
+
+class WebCommentController extends CommentController
+{
+    private CommentService $commentService;
+
+    public function __construct(
+        CommentService $commentService
+    ) {
+        parent::__construct();
+
+        $this->middleware('web');
+
+        $this->commentService = $commentService;
+    }
+
+    /**
+     * Creates a new comment for given model.
+     */
+    public function store(Request $request)
+    {
+        $comment = $this->commentService->store($request);
+
+        return Redirect::to(URL::previous() . '#comment-' . $comment->getKey());
+    }
+
+    /**
+     * Updates the message of the comment.
+     */
+    public function update(Request $request, Comment $comment)
+    {
+        $comment = $this->commentService->update($request, $comment);
+
+        return Redirect::to(URL::previous() . '#comment-' . $comment->getKey());
+    }
+
+    /**
+     * Deletes a comment.
+     */
+    public function destroy(Comment $comment)
+    {
+        $this->commentService->destroy($comment);
+
+        return Redirect::back();
+    }
+
+    /**
+     * Creates a reply "comment" to a comment.
+     */
+    public function reply(Request $request, Comment $comment)
+    {
+        $reply = $this->commentService->reply($request, $comment);
+
+        return Redirect::to(URL::previous() . '#comment-' . $reply->getKey());
+    }
+}


### PR DESCRIPTION
I've ran into this when using laravelista/comments in my own project; It doesn't work great when using it for building an API.

By extract most of the work to a Service-class, I aim to allow for easier usage when integrating on an api. Opposed to when using this lib for web/blade.

Let me know what you think!